### PR TITLE
更新: Init WorkspaceワークフローにVS Code workspace除外パターンを追加

### DIFF
--- a/.agent/README.md
+++ b/.agent/README.md
@@ -54,6 +54,7 @@ Antigravity のチャット欄で `@` を入力し、スキル名の一部（例
 
 | コマンド | 説明 | 主な出力 |
 |:---|:---|:---|
+| `/init_workspace` | 新規プロジェクト初期化 | Git初期化、README、AGENTS.md、.gitignore |
 | `/cxo_summit` | CXO会議の開催 | 各専門家の意見集約、議事録 |
 | `/create_event_plan` | イベント企画書の生成 | 企画書、Peatix説明文案 |
 | `/create_peatix_page` | Peatixページ作成 | イベントページ用テキスト |
@@ -108,5 +109,5 @@ Antigravity のチャット欄で `/` を入力すると利用可能なワーク
 
 ---
 
-**Last Updated**: 2026-03-22
+**Last Updated**: 2026-04-19
 **Maintained by**: Antigravity & Team

--- a/.agent/workflows/init_workspace.md
+++ b/.agent/workflows/init_workspace.md
@@ -25,7 +25,7 @@ Git初期化、各種ドキュメント（README.md / AGENTS.md）の生成、Gi
      - **AI/ツール関連:** `.claude`, `.gemini`, `.agent/scratch/`, `.gemini/`
      - **環境・秘匿情報:** `.env`, `*.local`, `config.json`（秘密情報を含む場合）
      - **OS関連:** `Thumbs.db`, `.DS_Store`
-     - **開発関連:** `node_modules/`, `__pycache__/`, `.vscode/`
+     - **開発関連:** `node_modules/`, `__pycache__/`, `.vscode/`, `*.code-workspace`
    
    *エラーハンドリング:*
    Gitコマンドが失敗した場合は、権限の問題や既に初期化済みでないかを確認し、ユーザーに状況を報告してください。


### PR DESCRIPTION
## 概要
Init Workspaceワークフローの `.gitignore` テンプレートに、VS Codeのワークスペースファイル（`*.code-workspace`）を除外するパターンを追加しました。

## 変更内容
- `.agent/workflows/init_workspace.md` の `.gitignore` テンプレートに `*.code-workspace` を追加

## 背景
VS Codeのワークスペースファイルは個人の開発環境設定であり、通常はバージョン管理の対象外とすべきです。この変更により、新規プロジェクト初期化時に適切な `.gitignore` が生成されるようになります。

## テストプラン
- [ ] ワークフローファイルの構文が正しいことを確認
- [ ] 他の `.gitignore` パターンとの整合性を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)